### PR TITLE
crypto: algif_aead - fix uninitialized ctx->init

### DIFF
--- a/crypto/algif_aead.c
+++ b/crypto/algif_aead.c
@@ -568,12 +568,6 @@ static int aead_accept_parent_nokey(void *private, struct sock *sk)
 
 	INIT_LIST_HEAD(&ctx->tsgl_list);
 	ctx->len = len;
-	ctx->used = 0;
-	atomic_set(&ctx->rcvused, 0);
-	ctx->more = 0;
-	ctx->merge = 0;
-	ctx->enc = 0;
-	ctx->aead_assoclen = 0;
 	af_alg_init_completion(&ctx->completion);
 
 	ask->private = ctx;

--- a/crypto/algif_skcipher.c
+++ b/crypto/algif_skcipher.c
@@ -371,6 +371,7 @@ static int skcipher_accept_parent_nokey(void *private, struct sock *sk)
 	ctx = sock_kmalloc(sk, len, GFP_KERNEL);
 	if (!ctx)
 		return -ENOMEM;
+	memset(ctx, 0, len);
 
 	ctx->iv = sock_kmalloc(sk, crypto_skcipher_ivsize(skcipher),
 			       GFP_KERNEL);
@@ -378,16 +379,10 @@ static int skcipher_accept_parent_nokey(void *private, struct sock *sk)
 		sock_kfree_s(sk, ctx, len);
 		return -ENOMEM;
 	}
-
 	memset(ctx->iv, 0, crypto_skcipher_ivsize(skcipher));
 
 	INIT_LIST_HEAD(&ctx->tsgl_list);
 	ctx->len = len;
-	ctx->used = 0;
-	atomic_set(&ctx->rcvused, 0);
-	ctx->more = 0;
-	ctx->merge = 0;
-	ctx->enc = 0;
 	af_alg_init_completion(&ctx->completion);
 
 	ask->private = ctx;


### PR DESCRIPTION
Hello,

This pull request is to ingest the patch as a follow-up fix of commit ("crypto: algif_aead - Only wake up when ctx->more is zero") to openela 4.14 kernel and they are together to fix the crypto encryption issue reported upstream: https://lore.kernel.org/all/20240320143143.1643630-1-ralph.siemsen@linaro.org/. Could you please help to add this patch? 

Thanks,
Shaoying